### PR TITLE
fix compile error on linux

### DIFF
--- a/common.h
+++ b/common.h
@@ -6,8 +6,8 @@ int setUid();
 int elevate(char *path, char *prompt, char *iconPath);
 #endif
 
-const char* proxyHost;
-const char* proxyPort;
+extern const char* proxyHost;
+extern const char* proxyPort;
 
 #ifdef _WIN32
 void setupSystemShutdownHandler();

--- a/main.c
+++ b/main.c
@@ -4,6 +4,10 @@
 #include <signal.h>
 #include "common.h"
 
+
+const char* proxyHost;
+const char* proxyPort;
+
 void usage(const char* binName)
 {
   printf("Usage: %s [show | on | off | wait-and-cleanup <proxy host> <proxy port>]\n", binName);


### PR DESCRIPTION
```
wphome@wphome:~/2.software/2.lantern/sysproxy-cmd/sysproxy-cmd[xxpyb/bf]$ make
gcc -Wall -c -D LINUX -pthread -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -D AMD64 linux.c common.h
gcc -Wall -c -D LINUX -pthread -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -D AMD64 main.c common.h
gcc -o binaries/linux_amd64/sysproxy linux.o main.o -lgio-2.0 -lgobject-2.0 -lglib-2.0
```
build pass and generate sysproxy-cmd binary